### PR TITLE
make trace anlyze and log injection conditional to apm enabled

### DIFF
--- a/yilu-common/README.md
+++ b/yilu-common/README.md
@@ -197,6 +197,11 @@ spec:
             configMapKeyRef:
               name: datadog-config
               key: apm.enabled
+        - name: DD_LOGS_INJECTION
+          valueFrom:
+            configMapKeyRef:
+              name: datadog-config
+              key: apm.enabled
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -322,12 +327,10 @@ will generate the code below, please configure your secret accordingly to match 
 
 ### Monitoring
 
-| Name                                 | Description                                | Value             |
-|--------------------------------------|--------------------------------------------|-------------------|
-| `datadog.serviceNameEnv`             | Environment variable name for service name | `DD_SERVICE_NAME` |
-| `datadog.autoTraceIdInjection`       | enable trace id injection                  | `false`           |
-| `datadog.traceAnalyticsEnabled`      | Enable trace analytics                     | `false`           |
-| `datadog.analyzedSpansEnabled.https` | Enable span analyze                        | `false`           |
+| Name                             | Description                                | Value             |
+|----------------------------------|--------------------------------------------|-------------------|
+| `datadog.serviceNameEnv`         | Environment variable name for service name | `DD_SERVICE_NAME` |
+| `datadog.analyzedSpansEnabled`   | Enable span analyze                        | `false`           |
 
 
 ### AutoScaling

--- a/yilu-common/templates/cronjob.yaml
+++ b/yilu-common/templates/cronjob.yaml
@@ -40,16 +40,18 @@ spec:
                 valueFrom:
                   fieldRef:
                     fieldPath: metadata.labels['simpletrip']
-                {{- if .Values.datadog.autoTraceIdInjection }}
               - name: DD_LOGS_INJECTION
-                value: 'true'
-                {{- end }}
-                {{- if .Values.datadog.traceAnalyticsEnabled }}
+                valueFrom:
+                  configMapKeyRef:
+                    name: datadog-config
+                    key: apm.enabled
               - name: DD_TRACE_ANALYTICS_ENABLED
-                value: 'true'
-                {{- end }}
-                {{- if .Values.datadog.analyzedSpansEnabled }}
+                valueFrom:
+                  configMapKeyRef:
+                    name: datadog-config
+                    key: apm.enabled
+              {{- if .Values.datadog.analyzedSpansEnabled }}
               - name: DD_APM_ANALYZED_SPANS
                 value: 'true'
-                {{- end }}
+              {{- end }}
 {{- end }}

--- a/yilu-common/templates/deployment.yaml
+++ b/yilu-common/templates/deployment.yaml
@@ -94,15 +94,20 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.labels['simpletrip']
-{{- if .Values.datadog.autoTraceIdInjection }}
         - name: DD_LOGS_INJECTION
-          value: 'true'
-{{- end }}
+          valueFrom:
+            configMapKeyRef:
+              name: datadog-config
+              key: apm.enabled
         - name: DD_TRACE_ANALYTICS_ENABLED
           valueFrom:
             configMapKeyRef:
               name: datadog-config
               key: apm.enabled
+{{- if .Values.datadog.analyzedSpansEnabled }}
+        - name: DD_APM_ANALYZED_SPANS
+          value: 'true'
+{{- end }}
 {{- if .Values.secrets.enabled }}
         volumeMounts:
         - name: {{ .Values.secrets.name }}

--- a/yilu-common/values.yaml
+++ b/yilu-common/values.yaml
@@ -37,12 +37,10 @@ extraEnv: []
 #  labels: |
 #    app.kubernetes.io/component: microservice
 #    app.kubernetes.io/part-of: booking
-labels: 
+labels: {}
 
 datadog:
   serviceNameEnv: DD_SERVICE_NAME
-  autoTraceIdInjection: false
-  traceAnalyticsEnabled: false
   analyzedSpansEnabled: false
 
 # SERVICE


### PR DESCRIPTION
* since on dev apm is not enabled on agent level, setting value to true doesn't matter, only apps throws error that trace port is not found
* datadog.analyzedSpansEnabled still adds env to analyze spans