### PR TITLE
Added ImageTag label to ExternalSecret

### DIFF
--- a/yilu-common/templates/externalsecret.yaml
+++ b/yilu-common/templates/externalsecret.yaml
@@ -3,6 +3,9 @@ apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ .Values.secrets.name }}
+  labels:
+    simpletrip: {{ include "common.name" . }}
+    imageTag: {{ .Values.image.tag }}
 spec:
   secretStoreRef:
     name: vault-backend


### PR DESCRIPTION
This will force recreation of externalsecret for every rollout to ensure that the latest secret is fetched from Vault.