### PR TITLE
Added revisionHistoryLimit parameter.

### DIFF
--- a/yilu-common/templates/deployment.yaml
+++ b/yilu-common/templates/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- include "common.tplvalues.render" (dict "value" .Values.labels "context" $) | nindent 4 }}
     {{- end }}
 spec:
+  revisionHistoryLimit: {{ .Values.deployment.revisionHistoryLimit }}
   selector:
     matchLabels:
       simpletrip: {{ include "common.name" . }}

--- a/yilu-common/values.yaml
+++ b/yilu-common/values.yaml
@@ -81,4 +81,4 @@ job:
 
 # Deployment
 deployment:
-  revisionHistoryLimit: 3
+  revisionHistoryLimit: 5

--- a/yilu-common/values.yaml
+++ b/yilu-common/values.yaml
@@ -79,4 +79,6 @@ job:
   args: []
   extraEnvConfigMapRef:
 
-
+# Deployment
+deployment:
+  revisionHistoryLimit: 3


### PR DESCRIPTION
Default value of revisionHistoryLimit parameter is 10 which displays a lot of replicasets in ArgoCD UI. We can try reducing this to 3 to remove the noise from UI also will clear up resources on k8s required to keep a history of all the replicasets.