### PR TITLE
Hotfix/add amp structure

### DIFF
--- a/yilu-common/templates/_helpers.tpl
+++ b/yilu-common/templates/_helpers.tpl
@@ -19,3 +19,11 @@ Usage:
         {{- tpl (.value | toYaml) .context }}
     {{- end }}
 {{- end -}}
+
+{{- define "common.repository" -}}
+{{- if eq .Values.amp "true" -}}
+{{- "{{ .Values.image.repository }}/amp" -}}
+{{- else -}}
+{{- .Values.image.repository -}}
+{{- end -}}
+{{- end -}}

--- a/yilu-common/templates/_helpers.tpl
+++ b/yilu-common/templates/_helpers.tpl
@@ -22,7 +22,7 @@ Usage:
 
 {{- define "common.repository" -}}
 {{- if eq .Values.amp "true" -}}
-{{- "{{ .Values.image.repository }}/amp" -}}
+{{- .Values.image.repository -}}{{- "/amp" -}}
 {{- else -}}
 {{- .Values.image.repository -}}
 {{- end -}}

--- a/yilu-common/templates/deployment.yaml
+++ b/yilu-common/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: {{ include "common.containerName" . }}
-        image: {{ .Values.image.repository }}/{{ template "common.name" . }}:{{ .Values.image.tag }}
+        image: {{ include "common.repository" . }}/{{ template "common.name" . }}:{{ .Values.image.tag }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- if .Values.args }}
         args: {{- include "common.tplvalues.render" (dict "value" .Values.args "context" $) | nindent 10 }}


### PR DESCRIPTION
- added changes in templates file and deployments file to cater for amp repo name structure.
- this new way adapts to both the amp ECR repository name and the old/normal repository name without the amp prefix.