### PR TITLE
YAF-4556: add vault static resource

### DIFF
--- a/yilu-common/Chart.yaml
+++ b/yilu-common/Chart.yaml
@@ -12,4 +12,4 @@ name: yilu-common
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1

--- a/yilu-common/README.md
+++ b/yilu-common/README.md
@@ -399,3 +399,34 @@ To know which exact `awsPermissionsRolePath` value to use for a given environmen
 | `job.command`                    | Command to run on the container                    | `""`    |
 | `job.args`                       | Extra args to pass to container                    | `[]`    |
 | `job.extraEnvConfigMapRef`       | Name of the configmap to inject to container       | `""`    |
+
+### Dynamic/Static Secrets (Vault Secrets Operator)
+
+| Name                             | Description                                        | Value   |
+|----------------------------------|--------------------------------------------------------|---------|
+| `secrets.vault.namespace` | Namespace in Vault where the secrets are created| `admin/yiluhub` |
+| `secrets.vault.vaultSecretsOperatorName`| Name of the Vault secrets operator name | `"vault-secrets-operator"` |
+| `secrets.vault.authRef`| vault secrets operator auth ref name prefixed with the namespace |`"vault-secrets-operator/default"` |
+| `secrets.dynamicSecrets.enabled` | This value enables the dynamic secrets | `false/true` |
+| `secrets.dynamicSecrets.mountPath` | The mount path at which the secrets engine is mounted | `"eg. aws/secrets-engine"` |
+| `secrets.dynamicSecrets.secrets.name` | The name of the of the secret to be created in k8s secret resource | `""` |
+| `secrets.dynamicSecrets.secrets.type` | The type of the dynamic secret | `"aws or database"` |
+| `secrets.dynamicSecrets.secrets.permissionsRolePath` | the dynamic secrets role path in vault | `"eg. creds/service-read"` |
+
+| `secrets.staticSecrets.enabled` | This value enables the static secrets | `false/true` |
+| `secrets.staticSecrets.mountPath` | The mount path at which the secrets engine is mounted | `"kv/service/secrets"` |
+| `secrets.staticSecrets.refreshInterval` | The refresh interval of the secret | `""` |
+| `secrets.staticSecrets.secretName` | The name of the secret to be created in k8s secrets resource | `""` |
+| `secrets.staticSecrets.secretPath` | The static secrets path in vault | `"worldshop"` |
+| `secrets.staticSecrets.version` | The vault version to use | `"1"` |
+| `secrets.staticSecrets.secretKeys` | The list of secret Keys that much the keys of the specific secret in vault | `[]` |
+
+### Secrets (External Secrets Operator)
+
+| `secrets.enabled` | This value enables the external secrets | `false/true` |
+| `secrets.name` | The name of the secret to be created in k8s secrets resource | `""` |
+| `secrets.refreshInterval` | The refresh interval of the secret | `""` |
+| `secrets.data.secretKey` | The key of the secret | `"application.yaml"` |
+| `secrets.data.remoteRef.parentKey` | The vault parent key/mount path for the data | `"kv/services/secrets/data"` |
+| `secrets.data.remoteRef.property` | The key of in the vault secret | `"application.yaml"` |
+| `secrets.data.remoteRef.decodingStrategy` | The decoding strategy | `Base64` |

--- a/yilu-common/README.md
+++ b/yilu-common/README.md
@@ -412,7 +412,6 @@ To know which exact `awsPermissionsRolePath` value to use for a given environmen
 | `secrets.dynamicSecrets.secrets.name` | The name of the of the secret to be created in k8s secret resource | `""` |
 | `secrets.dynamicSecrets.secrets.type` | The type of the dynamic secret | `"aws or database"` |
 | `secrets.dynamicSecrets.secrets.permissionsRolePath` | the dynamic secrets role path in vault | `"eg. creds/service-read"` |
-
 | `secrets.staticSecrets.enabled` | This value enables the static secrets | `false/true` |
 | `secrets.staticSecrets.mountPath` | The mount path at which the secrets engine is mounted | `"kv/service/secrets"` |
 | `secrets.staticSecrets.refreshInterval` | The refresh interval of the secret | `""` |
@@ -423,6 +422,8 @@ To know which exact `awsPermissionsRolePath` value to use for a given environmen
 
 ### Secrets (External Secrets Operator)
 
+| Name                             | Description                                        | Value   |
+|----------------------------------|--------------------------------------------------------|---------|
 | `secrets.enabled` | This value enables the external secrets | `false/true` |
 | `secrets.name` | The name of the secret to be created in k8s secrets resource | `""` |
 | `secrets.refreshInterval` | The refresh interval of the secret | `""` |

--- a/yilu-common/templates/deployment.yaml
+++ b/yilu-common/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- $secretName := .Values.secrets.staticSecrets.secretName }}
+{{- $secretName := .Values.secrets.staticSecrets.secretName -}}
 
 ---
 apiVersion: apps/v1

--- a/yilu-common/templates/deployment.yaml
+++ b/yilu-common/templates/deployment.yaml
@@ -1,4 +1,5 @@
 {{- $secretName := .Values.secrets.staticSecrets.secretName }}
+
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/yilu-common/templates/deployment.yaml
+++ b/yilu-common/templates/deployment.yaml
@@ -1,3 +1,5 @@
+{{- $secretName := .Values.secrets.staticSecrets.secretName }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -86,6 +88,43 @@ spec:
             secretKeyRef:
               name: {{ .Values.aws.secretKeyRefName }}
               key: secret
+{{- end }}
+{{- if .Values.secrets.dynamicSecrets.enabled }}
+{{- range .Values.secrets.dynamicSecrets.secrets }}
+{{- if eq .type "aws" }}
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: {{ .name }}
+              key: access_key
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .name }}
+              key: secret_key
+{{- end }}
+{{- if eq .type "database" }}
+        - name: USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ .name }}
+              key: username
+        - name: PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .name }}
+              key: password
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if .Values.secrets.staticSecrets.enabled }}
+{{- range .Values.secrets.staticSecrets.secretKeys }}
+        - name: {{ . }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ $secretName }}
+              key: {{ . }}
+{{- end }}
 {{- end }}
         - name: DD_AGENT_HOST
           valueFrom:

--- a/yilu-common/templates/deployment.yaml
+++ b/yilu-common/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: {{ include "common.containerName" . }}
-        image: {{ include "common.repository" . }}/{{ template "common.name" . }}:{{ .Values.image.tag }}
+        image: "{{ include "common.repository" . }}/{{ template "common.name" . }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- if .Values.args }}
         args: {{- include "common.tplvalues.render" (dict "value" .Values.args "context" $) | nindent 10 }}

--- a/yilu-common/templates/vaultSecret.yaml
+++ b/yilu-common/templates/vaultSecret.yaml
@@ -1,12 +1,12 @@
 {{- $serviceAccount := lookup "v1" "ServiceAccount" .Release.Namespace "vault-secrets-operator-sa" -}}
 {{- $secret := lookup "v1" "Secret" .Release.Namespace "vault-secrets-operator-sa-secret" -}}
 {{- $clusterRoleBinding := lookup "rbac.authorization.k8s.io/v1" "ClusterRoleBinding" "" "{{ .Release.Name }}-role-tokenreview-binding" -}}
-{{- $serviceName := (include "common.name" .) }}
-{{- $namespace := .Values.secrets.vault.namespace }}
-{{- $vaultAuthRef := .Values.secrets.vault.authRef }}
-{{- $dynamicSecretsEngineMountPath := .Values.secrets.dynamicSecrets.secretsEngineMountPath }}
-{{- $staticSecretsEngineMountPath := .Values.secrets.staticSecrets.secretsEngineMountPath }}
-{{- $staticSecretsName := .Values.secrets.staticSecrets.secretName }}
+{{- $serviceName := (include "common.name" .) -}}
+{{- $namespace := .Values.secrets.vault.namespace -}}
+{{- $vaultAuthRef := .Values.secrets.vault.authRef -}}
+{{- $dynamicSecretsEngineMountPath := .Values.secrets.dynamicSecrets.secretsEngineMountPath -}}
+{{- $staticSecretsEngineMountPath := .Values.secrets.staticSecrets.secretsEngineMountPath -}}
+{{- $staticSecretsName := .Values.secrets.staticSecrets.secretName -}}
 
 ---
 {{- if .Values.secrets.staticSecrets.enabled }}
@@ -53,7 +53,7 @@ spec:
 {{- end }}
 
 ---
-{{- if not $serviceAccount -}}
+{{- if not $serviceAccount }}
 # The name of this service account must match that defined in the vault secrets operator namespace
 apiVersion: v1
 kind: ServiceAccount
@@ -63,7 +63,7 @@ metadata:
 {{- end }}
 
 ---
-{{- if not $secret -}}
+{{- if not $secret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -75,7 +75,7 @@ type: kubernetes.io/service-account-token
 {{- end }}
 
 ---
-{{- if not $clusterRoleBinding -}}
+{{- if not $clusterRoleBinding }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/yilu-common/templates/vaultSecret.yaml
+++ b/yilu-common/templates/vaultSecret.yaml
@@ -4,8 +4,8 @@
 {{- $serviceName := (include "common.name" .) -}}
 {{- $namespace := .Values.secrets.vault.namespace -}}
 {{- $vaultAuthRef := .Values.secrets.vault.authRef -}}
-{{- $dynamicSecretsEngineMountPath := .Values.secrets.dynamicSecrets.secretsEngineMountPath -}}
-{{- $staticSecretsEngineMountPath := .Values.secrets.staticSecrets.secretsEngineMountPath -}}
+{{- $dynamicSecretsEngineMountPath := .Values.secrets.dynamicSecrets.mountPath -}}
+{{- $staticSecretsEngineMountPath := .Values.secrets.staticSecrets.mountPath -}}
 {{- $staticSecretsName := .Values.secrets.staticSecrets.secretName -}}
 
 ---
@@ -19,7 +19,7 @@ metadata:
 spec:
   namespace: {{ $namespace }}
   vaultAuthRef: {{ $vaultAuthRef }}
-  mount: {{ $staticSecretsEngineMountPath | default "kv/services/secrets" }}
+  mount: {{ $staticSecretsEngineMountPath }}
   type: kv-v2
   path: {{  .Values.secrets.staticSecrets.secretPath }}
   version: {{  .Values.secrets.staticSecrets.version | default "1" }}
@@ -42,7 +42,7 @@ spec:
   namespace: {{ $namespace }}
   vaultAuthRef: {{ $vaultAuthRef }}
   mount: {{ $dynamicSecretsEngineMountPath }}
-  path: {{ .dynamicPermissionsRole }}
+  path: {{ .awsPermissionsRolePath }}
   destination:
     name: {{ .name }}
     create: true

--- a/yilu-common/templates/vaultSecret.yaml
+++ b/yilu-common/templates/vaultSecret.yaml
@@ -42,7 +42,7 @@ spec:
   namespace: {{ $namespace }}
   vaultAuthRef: {{ $vaultAuthRef }}
   mount: {{ $dynamicSecretsEngineMountPath }}
-  path: {{ .awsPermissionsRolePath }}
+  path: {{ .permissionsRolePath }}
   destination:
     name: {{ .name }}
     create: true

--- a/yilu-common/templates/vaultSecret.yaml
+++ b/yilu-common/templates/vaultSecret.yaml
@@ -7,6 +7,7 @@
 {{- $dynamicSecretsEngineMountPath := .Values.secrets.dynamicSecrets.secretsEngineMountPath }}
 {{- $staticSecretsEngineMountPath := .Values.secrets.staticSecrets.secretsEngineMountPath }}
 {{- $staticSecretsName := .Values.secrets.staticSecrets.secretName }}
+
 ---
 {{- if .Values.secrets.staticSecrets.enabled }}
 apiVersion: secrets.hashicorp.com/v1beta1
@@ -27,6 +28,7 @@ spec:
     name: {{ $staticSecretsName }}
     create: true
 {{- end }}
+
 ---
 {{- if .Values.secrets.dynamicSecrets.enabled }}
 {{- range .Values.secrets.dynamicSecrets.secrets }}
@@ -49,6 +51,7 @@ spec:
       name: {{ $serviceName }}
 {{- end }}
 {{- end }}
+
 ---
 {{- if not $serviceAccount -}}
 # The name of this service account must match that defined in the vault secrets operator namespace
@@ -58,6 +61,7 @@ metadata:
   name: {{ .Values.secrets.vault.vaultSecretsOperatorName }}-sa
   namespace: {{ .Release.Namespace }}
 {{- end }}
+
 ---
 {{- if not $secret -}}
 apiVersion: v1
@@ -69,6 +73,7 @@ metadata:
     kubernetes.io/service-account.name: {{ .Values.secrets.vault.vaultSecretsOperatorName }}-sa
 type: kubernetes.io/service-account-token
 {{- end }}
+
 ---
 {{- if not $clusterRoleBinding -}}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/yilu-common/templates/vaultSecret.yaml
+++ b/yilu-common/templates/vaultSecret.yaml
@@ -1,32 +1,56 @@
-{{- if .Values.secrets.enabled }}
-{{- $VaultDynamicSecret := lookup "secrets.hashicorp.com/v1beta1" "VaultDynamicSecret" .Release.Namespace .Values.secrets.name -}}
-{{- $ServiceAccount := lookup "v1" "ServiceAccount" .Release.Namespace "vault-secrets-operator-sa" -}}
-{{- $Secret := lookup "v1" "Secret" .Release.Namespace "vault-secrets-operator-sa-secret" -}}
-{{- $ClusterRoleBinding := lookup "rbac.authorization.k8s.io/v1" "ClusterRoleBinding" "" "{{ .Release.Name }}-role-tokenreview-binding" -}}
-
-{{- if not $VaultDynamicSecret -}}
+{{- $serviceAccount := lookup "v1" "ServiceAccount" .Release.Namespace "vault-secrets-operator-sa" -}}
+{{- $secret := lookup "v1" "Secret" .Release.Namespace "vault-secrets-operator-sa-secret" -}}
+{{- $clusterRoleBinding := lookup "rbac.authorization.k8s.io/v1" "ClusterRoleBinding" "" "{{ .Release.Name }}-role-tokenreview-binding" -}}
+{{- $serviceName := (include "common.name" .) }}
+{{- $namespace := .Values.secrets.vault.namespace }}
+{{- $vaultAuthRef := .Values.secrets.vault.authRef }}
+{{- $dynamicSecretsEngineMountPath := .Values.secrets.dynamicSecrets.secretsEngineMountPath }}
+{{- $staticSecretsEngineMountPath := .Values.secrets.staticSecrets.secretsEngineMountPath }}
+{{- $staticSecretsName := .Values.secrets.staticSecrets.secretName }}
+---
+{{- if .Values.secrets.staticSecrets.enabled }}
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: {{ $staticSecretsName }}
+  labels:
+    simpletrip: {{ $serviceName }}
+spec:
+  namespace: {{ $namespace }}
+  vaultAuthRef: {{ $vaultAuthRef }}
+  mount: {{ $staticSecretsEngineMountPath | default "kv/services/secrets" }}
+  type: kv-v2
+  path: {{  .Values.secrets.staticSecrets.secretPath }}
+  version: {{  .Values.secrets.staticSecrets.version | default "1" }}
+  refreshAfter: {{ .Values.secrets.staticSecrets.refreshInterval }}
+  destination:
+    name: {{ $staticSecretsName }}
+    create: true
+{{- end }}
+---
+{{- if .Values.secrets.dynamicSecrets.enabled }}
+{{- range .Values.secrets.dynamicSecrets.secrets }}
 apiVersion: secrets.hashicorp.com/v1beta1
 kind: VaultDynamicSecret
 metadata:
-  name: {{ .Values.secrets.name }}
+  name: {{ .name }}
   labels:
-    simpletrip: {{ include "common.name" . }}
-    imageTag: {{ quote .Values.image.tag }}
+    simpletrip: {{ $serviceName }}
 spec:
-  namespace: {{ .Values.secrets.vault.namespace }}
-  vaultAuthRef: {{ .Values.secrets.vault.authRef }}
-  mount: {{ .Values.secrets.vault.secretsEngineMount }}
-  path: {{ .Values.secrets.vault.awsPermissionsRole }}
+  namespace: {{ $namespace }}
+  vaultAuthRef: {{ $vaultAuthRef }}
+  mount: {{ $dynamicSecretsEngineMountPath }}
+  path: {{ .dynamicPermissionsRole }}
   destination:
-    name: {{ .Values.secrets.name }}
+    name: {{ .name }}
     create: true
   rolloutRestartTargets:
     - kind: Deployment
-      name: {{ include "common.name" . }}
+      name: {{ $serviceName }}
 {{- end }}
-
+{{- end }}
 ---
-{{- if not $ServiceAccount -}}
+{{- if not $serviceAccount -}}
 # The name of this service account must match that defined in the vault secrets operator namespace
 apiVersion: v1
 kind: ServiceAccount
@@ -34,9 +58,8 @@ metadata:
   name: {{ .Values.secrets.vault.vaultSecretsOperatorName }}-sa
   namespace: {{ .Release.Namespace }}
 {{- end }}
-
 ---
-{{- if not $Secret -}}
+{{- if not $secret -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -46,9 +69,8 @@ metadata:
     kubernetes.io/service-account.name: {{ .Values.secrets.vault.vaultSecretsOperatorName }}-sa
 type: kubernetes.io/service-account-token
 {{- end }}
-
 ---
-{{- if not $ClusterRoleBinding -}}
+{{- if not $clusterRoleBinding -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -61,5 +83,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ .Values.secrets.vault.vaultSecretsOperatorName }}-sa
     namespace: {{ .Release.Namespace }}
-{{- end }}
 {{- end }}

--- a/yilu-common/values.yaml
+++ b/yilu-common/values.yaml
@@ -26,17 +26,17 @@ secrets:
     # authRef is the name of the Vault Auth resource deployed as part of the vault secrets operator. The value is namespace prefixed
   dynamicSecrets:
     enabled: false
-    secretsEngineMountPath: aws/secret-engine
+    mountPath: "aws/secret-engine"
     secrets:
       - name: ""
         type: aws
-        dynamicPermissionsRole: ""
+        awsPermissionsRolePath: "" # example creds/service-read
   staticSecrets:
     enabled: false
-    secretsEngineMountPath: kv/services/secrets
+    mountPath: "kv/services/secrets"
     refreshInterval: 1h
-    secretName: ""
-    secretPath: ""
+    secretName: "" # example worldshop-secrets, this is the name of the secret created in k8s
+    secretPath: "" # example worldshop
     version: 1
     secretKeys: []
   enabled: false

--- a/yilu-common/values.yaml
+++ b/yilu-common/values.yaml
@@ -30,7 +30,7 @@ secrets:
     secrets:
       - name: ""
         type: aws
-        awsPermissionsRolePath: "" # example creds/service-read
+        permissionsRolePath: "" # example creds/service-read
   staticSecrets:
     enabled: false
     mountPath: "kv/services/secrets"

--- a/yilu-common/values.yaml
+++ b/yilu-common/values.yaml
@@ -19,6 +19,26 @@ readinessProbe:
 
 # Inject secrets
 secrets:
+  vault:
+    namespace: admin/yiluhub/
+    vaultSecretsOperatorName: vault-secrets-operator
+    authRef: vault-secrets-operator/default
+    # authRef is the name of the Vault Auth resource deployed as part of the vault secrets operator. The value is namespace prefixed
+  dynamicSecrets:
+    enabled: false
+    secretsEngineMountPath: aws/secret-engine
+    secrets:
+      - name: ""
+        type: aws
+        dynamicPermissionsRole: ""
+  staticSecrets:
+    enabled: false
+    secretsEngineMountPath: kv/services/secrets
+    refreshInterval: 1h
+    secretName: ""
+    secretPath: ""
+    version: 1
+    secretKeys: []
   enabled: false
   name: ""
   refreshInterval: 1h
@@ -28,13 +48,6 @@ secrets:
       parentKey: kv/services/secrets/data
       property: application.yaml
       decodingStrategy: Base64
-  vault:
-    namespace: admin/yiluhub/
-    # authRef is the name of the Vault Auth resource deployed as part of the vault secrets operator. The value is namespace prefixed
-    authRef: vault-secrets-operator/default
-    secretsEngineMount: aws/secret-engine
-    awsPermissionsRole: ""
-    vaultSecretsOperatorName: vault-secrets-operator
 
 # aws:
 aws:


### PR DESCRIPTION
# Pull Request

> Tracked in JIRA by [YAF-4556](https://yiluts.atlassian.net/browse/YAF-4556)

## Scope of the PR

- added vault static secret resource
- modified naming for the vault dynamic secret resource
- added values to the deployment resource in a more clear and clean way

## Considerations / Implementation Details

- The changes are quite many

Helm template command output:

```yaml
---
# Source: yilu-common/templates/vaultSecret.yaml
# The name of this service account must match that defined in the vault secrets operator namespace
apiVersion: v1
kind: ServiceAccount
metadata:
  name: vault-secrets-operator-sa
  namespace: default
---
# Source: yilu-common/templates/vaultSecret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: vault-secrets-operator-sa-secret
  namespace: default
  annotations:
    kubernetes.io/service-account.name: vault-secrets-operator-sa
type: kubernetes.io/service-account-token
---
# Source: yilu-common/templates/vaultSecret.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: default-role-tokenreview-binding
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: system:auth-delegator
subjects:
  - kind: ServiceAccount
    name: vault-secrets-operator-sa
    namespace: default
---
# Source: yilu-common/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: demo-service
  labels:
    simpletrip: demo-service
spec:
  type: ClusterIP
  ports:
  - port: 4000
    name: http
  selector:
    simpletrip: demo-service
---
# Source: yilu-common/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: demo-service
  labels:
    simpletrip: demo-service
    app.kubernetes.io/component: microservice
    app.kubernetes.io/part-of: worldshop-pricing-service
    
spec:
  revisionHistoryLimit: 5
  selector:
    matchLabels:
      simpletrip: demo-service
  template:
    metadata:
      labels:
        simpletrip: demo-service
        app.kubernetes.io/name: demo-service
        app.kubernetes.io/version: "1.0"
        app.kubernetes.io/component: microservice
        app.kubernetes.io/part-of: worldshop-pricing-service
        
    spec:
      containers:
      - name: worldshop-pricing-service
        image: "432560034976.dkr.ecr.eu-central-1.amazonaws.com/yiluhub/demo-service:latest"
        imagePullPolicy: Always
        resources:
          limits:
            cpu: 1
            memory: 2Gi
          requests:
            cpu: 1
            memory: 2Gi
        ports:
        - containerPort: 4000
        envFrom:
        - configMapRef:
            name: spring-boot-cloud
        - configMapRef:
            name: mock-clients-configuration
            optional: true
        livenessProbe:
          httpGet:
            path: /worldshop/health
            port: 4000
          initialDelaySeconds: 300
        readinessProbe:
          httpGet:
            path: /worldshop/health
            port: 4000
          initialDelaySeconds: 30
        env:
        - name: PORT
          value: "4000"
        - name: LOG_ENABLED
          value: "true"
        - name: PRICING_CACHE_KEY
          value: PRODUCT_PRICING_WORLDSHOP
        - name: REDIS_HOST
          value: redis.common.internal.yiluhub.com
        - name: SPRING_ENVIRONMENT
          valueFrom:
            configMapKeyRef:
              name: spring-boot-cloud
              key: spring.environment
        - name: CLOUD_ENVIRONMENT
          valueFrom:
            configMapKeyRef:
              name: spring-boot-cloud
              key: cloud.environment
        - name: SERVER_PORT
          value: "4000"
        - name: AWS_ACCESS_KEY_ID
          valueFrom:
            secretKeyRef:
              name: some-name
              key: access_key
        - name: AWS_SECRET_ACCESS_KEY
          valueFrom:
            secretKeyRef:
              name: some-name
              key: secret_key
        - name: TOKEN
          valueFrom:
            secretKeyRef:
              name: worldshop-secrets
              key: TOKEN
        - name: THIS
          valueFrom:
            secretKeyRef:
              name: worldshop-secrets
              key: THIS
        - name: DD_AGENT_HOST
          valueFrom:
            fieldRef:
              fieldPath: status.hostIP
        - name: DD_TRACE_ENABLED
          valueFrom:
            configMapKeyRef:
              name: datadog-config
              key: apm.enabled
        - name: DD_SERVICE_NAME
          valueFrom:
            fieldRef:
              fieldPath: metadata.labels['simpletrip']
        - name: DD_LOGS_INJECTION
          valueFrom:
            configMapKeyRef:
              name: datadog-config
              key: apm.enabled
        - name: DD_TRACE_ANALYTICS_ENABLED
          valueFrom:
            configMapKeyRef:
              name: datadog-config
              key: apm.enabled
      affinity:
        podAntiAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
          - labelSelector:
              matchExpressions:
              - key: simpletrip
                operator: In
                values:
                - demo-service
            topologyKey: kubernetes.io/hostname
      nodeSelector:
        role: general-purpose
  strategy:
    type: RollingUpdate
    rollingUpdate:
      maxSurge: 1
      maxUnavailable: 0
---
# Source: yilu-common/templates/hpa.yaml
apiVersion: autoscaling/v1
kind: HorizontalPodAutoscaler
metadata:
  name: demo-service
spec:
  minReplicas: 1
  maxReplicas: 10
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: demo-service
  targetCPUUtilizationPercentage: 80
---
# Source: yilu-common/templates/vaultSecret.yaml
apiVersion: secrets.hashicorp.com/v1beta1
kind: VaultDynamicSecret
metadata:
  name: some-name
  labels:
    simpletrip: demo-service
spec:
  namespace: admin/yiluhub/
  vaultAuthRef: vault-secrets-operator/default
  mount: aws/secret-engine
  path: creds/service-read
  destination:
    name: some-name
    create: true
  rolloutRestartTargets:
    - kind: Deployment
      name: demo-service
---
# Source: yilu-common/templates/vaultSecret.yaml
apiVersion: secrets.hashicorp.com/v1beta1
kind: VaultStaticSecret
metadata:
  name: worldshop-secrets
  labels:
    simpletrip: demo-service
spec:
  namespace: admin/yiluhub/
  vaultAuthRef: vault-secrets-operator/default
  mount: kv/services/secrets
  type: kv-v2
  path: worldshop
  version: 1
  refreshAfter: 1h
  destination:
    name: worldshop-secrets
    create: true

```

[YAF-4556]: https://yiluts.atlassian.net/browse/YAF-4556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ