### PR TITLE
Bug/YAF-4737 bugfix for v0.6.3

### DIFF
--- a/yilu-common/Chart.yaml
+++ b/yilu-common/Chart.yaml
@@ -12,4 +12,4 @@ name: yilu-common
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.3
+version: 0.6.4

--- a/yilu-common/templates/vaultSecret.yaml
+++ b/yilu-common/templates/vaultSecret.yaml
@@ -49,37 +49,3 @@ spec:
       name: {{ $serviceName }}
 {{- end }}
 {{- end }}
-
----
-{{- if or .Values.secrets.staticSecrets.enabled .Values.secrets.dynamicSecrets.enabled }}
-# The name of this service account must match that defined in the vault secrets operator namespace
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ .Values.secrets.vault.vaultSecretsOperatorName }}-sa
-  namespace: {{ .Release.Namespace }}
-
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ .Values.secrets.vault.vaultSecretsOperatorName }}-sa-secret
-  namespace: {{ .Release.Namespace }}
-  annotations:
-    kubernetes.io/service-account.name: {{ .Values.secrets.vault.vaultSecretsOperatorName }}-sa
-type: kubernetes.io/service-account-token
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ .Release.Namespace }}-role-tokenreview-binding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: system:auth-delegator
-subjects:
-  - kind: ServiceAccount
-    name: {{ .Values.secrets.vault.vaultSecretsOperatorName }}-sa
-    namespace: {{ .Release.Namespace }}
-{{- end }}


### PR DESCRIPTION
# Pull Request

> Tracked in JIRA by [YAF-4737](https://yiluts.atlassian.net/browse/YAF-4737)

## Scope of the PR

- remove secret, service account and clusterrole binding from common chart, change of implementation for authenticating to vault. this new way uses the central auth as before but without duplicating the resources as before. The resources existed in both namespace of the VSO and application since there was no way to use the auth.
- Since helm chart v0.5.0, released in December 2023, "allowedNamespaces" was introduced and this allows VDS and VSS  in any other namespace to use the vault auth in the VSO namespace.

## Considerations / Implementation Details

none


[YAF-4737]: https://yiluts.atlassian.net/browse/YAF-4737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ