### PR TITLE
Added timeouts to liveness and readiness probes.

### DIFF
--- a/yilu-common/templates/deployment.yaml
+++ b/yilu-common/templates/deployment.yaml
@@ -50,11 +50,13 @@ spec:
             path: {{ .Values.livenessProbe.path }}
             port: {{ .Values.service.port }}
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
         readinessProbe:
           httpGet:
             path: {{ .Values.readinessProbe.path }}
             port: {{ .Values.service.port }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
         env:
         {{- if .Values.extraEnv }}
         {{- include "common.tplvalues.render" (dict "value" .Values.extraEnv "context" $) | nindent 8 }}

--- a/yilu-common/values.yaml
+++ b/yilu-common/values.yaml
@@ -12,10 +12,12 @@ args: []
 livenessProbe:
   path: /actuator/health
   initialDelaySeconds: 300
+  timeoutSeconds: 3
 
 readinessProbe:
   path: /actuator/health
   initialDelaySeconds: 30
+  timeoutSeconds: 3
 
 # Inject secrets
 secrets:


### PR DESCRIPTION
# Pull Request

> Tracked in JIRA by [DHANC-13744](https://trackspace.lhsystems.com/browse/DHANC-13744)

## Scope of the PR

Increased the default timeout values for liveness and readiness probes from 1 second to 3 seconds. This could be helpful when /actuator/health endpoint takes longer under load. So k8s does not terminate the pod needlessly.

